### PR TITLE
Revert "Bump pymdown-extensions from 6.2.1 to 6.3"

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -3,4 +3,4 @@ mkdocs-git-revision-date-plugin==0.2
 mkdocs-macros-plugin==0.2.4
 mkdocs-material==4.6.0
 mkdocs-minify-plugin==0.2.1
-pymdown-extensions==6.3
+pymdown-extensions==6.2.1


### PR DESCRIPTION
Reverts UNCG-DAISY/psi-collect#69

Causes a compatibility issue that prevents docs from building.